### PR TITLE
Update _fonts.scss

### DIFF
--- a/src/fonts/_fonts.scss
+++ b/src/fonts/_fonts.scss
@@ -1,5 +1,2 @@
 //Helvetica
 @import url('https://fonts.cdnfonts.com/css/helvetica-neue-55');
-
-//Georgia
-@import url('https://fonts.cdnfonts.com/css/georgia');


### PR DESCRIPTION
there is no need to call georgia font from any cdn since it comes preinstalled on windows and mac